### PR TITLE
Add default option to reset CUDA environment in switch-cuda.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,44 @@ Switched to CUDA 9.0.
 $ source switch-cuda.sh default
 CUDA environment has been reset to default.
 ```
+
+Conda Integration
+--------
+You can automatically switch to a specific CUDA version when activating a conda environment by adding a hook inside the environment’s `etc/conda/activate.d` and `etc/conda/deactivate.d` directories.
+
+**Example:**
+
+Assuming your environment is located at `~/miniconda3/envs/YOUR_ENV_NAME` and your "switch-cuda.sh" is located at `~/switch-cuda.sh`. The CUDA version you want to use in your environment is `12.1`.
+
+Create the following two scripts:
+```
+~/miniconda3/envs/YOUR_ENV_NAME/etc/conda/activate.d/set-cuda.sh
+~/miniconda3/envs/YOUR_ENV_NAME/etc/conda/deactivate.d/reset-cuda.sh
+```
+
+**activate.d/set-cuda.sh**
+```
+#!/bin/bash
+source ~/Projects/switch-cuda.sh 12.1
+```
+**activate.d/reset-cuda.sh**
+```
+#!/bin/bash
+source ~/Projects/switch-cuda.sh default
+```
+
+**Usage**
+
+Now, whenever you activate `YOUR_ENV_NAME`:
+```
+conda activate YOUR_ENV_NAME
+```
+It will automatically switch to `12.1`.
+
+And when you deactivate:
+```
+conda deactivate
+```
+It will reset back to the system default CUDA setup.
+
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ switch-cuda
 
 Sometimes, it becomes necessary to switch to an earlier version of CUDA in order to run older code on a machine that is
 actually set up to use the current version of the CUDA toolkit.
+
 This is as simple as adjusting the values of a few environment variables, yet it is cumbersome to do manually.
 Therefore, this repository provides the bash script [`switch-cuda.sh`](switch-cuda.sh), which adjusts the environment to
 use a specific version of CUDA **for the current bash session**.
@@ -19,11 +20,16 @@ source switch-cuda.sh [VERSION]
 ```
 
 Notice that the script has to be sourced rather than executed, as it performs changes of environment variables that are
-supposed to persist after the script has finished.
+supposed to persist after the script has finished. 
+
 If a version number is provided, than all relevant environment variables are adjusted to the required CUDA version
-(including `PATH`, `LD_LIBRARY_PATH`, `CUDA_HOME`, and `CUDA_ROOT`).
+(including `PATH`, `LD_LIBRARY_PATH`, `CUDA_HOME`, and `CUDA_ROOT`). 
+
+If the special argument `default` is provided, the script clears these environment variables and restores the system’s
+default CUDA setup (as determined by the `/usr/local/cuda` symbolic link). 
+
 If no version is provided, however, then the script simply prints all versions of CUDA that have been found on the used
-machine (in `/usr/local`).
+machine (in `/usr/local`). 
 
 
 Examples
@@ -40,4 +46,9 @@ The following CUDA installations have been found (in '/usr/local'):
 ```
 $ source switch-cuda.sh 9.0
 Switched to CUDA 9.0.
+```
+
+```
+$ source switch-cuda.sh default
+CUDA environment has been reset to default.
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 switch-cuda
 ===========
 
+(Chinese version) 中文版使用说明可以看这里：https://yipko.com/posts/work/cuda-switcher-with-conda/
+
 Sometimes, it becomes necessary to switch to an earlier version of CUDA in order to run older code on a machine that is
 actually set up to use the current version of the CUDA toolkit.
 

--- a/README.md
+++ b/README.md
@@ -1,97 +1,165 @@
 switch-cuda
 ===========
 
-(Chinese version) 中文版使用说明可以看这里：https://yipko.com/posts/work/cuda-switcher-with-conda/
+<details>
+<summary><strong>🤖For LLM Agents: </strong></summary>
+Fetch the installation guide and follow it:
 
-Sometimes, it becomes necessary to switch to an earlier version of CUDA in order to run older code on a machine that is
-actually set up to use the current version of the CUDA toolkit.
+**Step 1: Ask user parameters**
 
-This is as simple as adjusting the values of a few environment variables, yet it is cumbersome to do manually.
-Therefore, this repository provides the bash script [`switch-cuda.sh`](switch-cuda.sh), which adjusts the environment to
-use a specific version of CUDA **for the current bash session**.
+- `SCRIPT_PATH` (default: `~/switch-cuda.sh`)
+- Conda environment name (`ENV_NAME`)
+- CUDA version (`CUDA_VERSION`), selected from detected installed versions
+- Whether to overwrite existing hook files
 
-**Notice:** [`switch-cuda.sh`](switch-cuda.sh) has been written for and tested on Ubuntu 16.04, but is easily adapted
-for other platforms.
+**Step 2: Validate and detect**
+
+```bash
+test -f "$SCRIPT_PATH" || wget -O "$SCRIPT_PATH" https://raw.githubusercontent.com/YipKo/switch-cuda/refs/heads/master/switch-cuda.sh
+source "$SCRIPT_PATH"          # list installed CUDA versions
+conda info --envs
+test -n "$CONDA_PREFIX" || echo "please activate target env first"
+```
+
+**Step 3: Create hook directories**
+
+```bash
+mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
+mkdir -p "$CONDA_PREFIX/etc/conda/deactivate.d"
+```
+
+**Step 4: Write activate hook**
+
+```bash
+cat > "$CONDA_PREFIX/etc/conda/activate.d/set-cuda.sh" <<EOF
+#!/bin/bash
+source "$SCRIPT_PATH" "$CUDA_VERSION"
+EOF
+chmod +x "$CONDA_PREFIX/etc/conda/activate.d/set-cuda.sh"
+```
+
+**Step 5: Write deactivate hook**
+
+```bash
+cat > "$CONDA_PREFIX/etc/conda/deactivate.d/reset-cuda.sh" <<EOF
+#!/bin/bash
+source "$SCRIPT_PATH" default
+EOF
+chmod +x "$CONDA_PREFIX/etc/conda/deactivate.d/reset-cuda.sh"
+```
+
+**Step 6: Verify**
+
+```bash
+conda deactivate && conda activate "$ENV_NAME"
+echo "$CUDA_HOME"
+which nvcc
+```
+
+</details>
+
+Docs
+----
+
+- Chinese tutorial: https://yipko.com/posts/work/cuda-switcher-with-conda/
+- English tutorial: https://yipko.com/en/posts/work/cuda-switcher-with-conda/
+
+Sometimes you need to switch to an older CUDA version to run legacy code on a machine configured with a newer toolkit.
+
+This can be done by changing a few environment variables, but doing it manually is tedious. This repository provides [`switch-cuda.sh`](switch-cuda.sh), which switches CUDA **for the current shell session**.
+
+**Notice:** [`switch-cuda.sh`](switch-cuda.sh) was originally tested on Ubuntu and is typically easy to adapt for other Linux distributions.
+
+
+Install
+-------
+
+Check whether the script already exists locally. Download only if missing:
+
+```bash
+test -f ~/switch-cuda.sh && echo "switch-cuda.sh already exists, skip download" || wget -O ~/switch-cuda.sh https://raw.githubusercontent.com/YipKo/switch-cuda/refs/heads/master/switch-cuda.sh
+```
 
 
 Usage
 -----
 
-```
+```bash
 source switch-cuda.sh [VERSION]
 ```
 
-Notice that the script has to be sourced rather than executed, as it performs changes of environment variables that are
-supposed to persist after the script has finished. 
+You must use `source` (not execute directly), because the script modifies environment variables that should persist in the current shell.
 
-If a version number is provided, than all relevant environment variables are adjusted to the required CUDA version
-(including `PATH`, `LD_LIBRARY_PATH`, `CUDA_HOME`, and `CUDA_ROOT`). 
-
-If the special argument `default` is provided, the script clears these environment variables and restores the system’s
-default CUDA setup (as determined by the `/usr/local/cuda` symbolic link). 
-
-If no version is provided, however, then the script simply prints all versions of CUDA that have been found on the used
-machine (in `/usr/local`). 
+- If a version is provided (e.g. `11.8`), it updates `PATH`, `LD_LIBRARY_PATH`, `CUDA_HOME`, and `CUDA_ROOT`.
+- If `default` is provided, it clears these variables and restores system default CUDA (from `/usr/local/cuda` symlink).
+- If no version is provided, it lists installed CUDA versions found under `/usr/local`.
 
 
 Examples
 --------
 
-```
-$ source switch-cuda.sh 
+```bash
+$ source switch-cuda.sh
 The following CUDA installations have been found (in '/usr/local'):
-* cuda-8.0
-* cuda-9.0
-* cuda-9.1
+* cuda-11.5
+* cuda-11.8
+* cuda-12.6
 ```
 
-```
-$ source switch-cuda.sh 9.0
-Switched to CUDA 9.0.
+```bash
+$ source switch-cuda.sh 11.8
+Switched to CUDA 11.8.
 ```
 
-```
+```bash
 $ source switch-cuda.sh default
 CUDA environment has been reset to default.
 ```
 
+
 Conda Integration
---------
-You can automatically switch to a specific CUDA version when activating a conda environment by adding a hook inside the environment’s `etc/conda/activate.d` and `etc/conda/deactivate.d` directories.
+-----------------
 
-**Example:**
+You can auto-switch CUDA when activating/deactivating a conda environment by adding hooks in `etc/conda/activate.d` and `etc/conda/deactivate.d`.
 
-Assuming your environment is located at `~/miniconda3/envs/YOUR_ENV_NAME` and your "switch-cuda.sh" is located at `~/switch-cuda.sh`. The CUDA version you want to use in your environment is `12.1`.
+**Example assumptions:**
 
-Create the following two scripts:
+- Conda env: `YOUR_ENV_NAME`
+- Script path: `~/switch-cuda.sh`
+- Desired CUDA for this env: `12.1`
+
+Create hook directories:
+
+```bash
+conda activate YOUR_ENV_NAME
+mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
+mkdir -p "$CONDA_PREFIX/etc/conda/deactivate.d"
 ```
-~/miniconda3/envs/YOUR_ENV_NAME/etc/conda/activate.d/set-cuda.sh
-~/miniconda3/envs/YOUR_ENV_NAME/etc/conda/deactivate.d/reset-cuda.sh
-```
 
-**activate.d/set-cuda.sh**
-```
+`$CONDA_PREFIX/etc/conda/activate.d/set-cuda.sh`
+
+```bash
 #!/bin/bash
-source ~/Projects/switch-cuda.sh 12.1
+source ~/switch-cuda.sh 12.1
 ```
-**activate.d/reset-cuda.sh**
-```
+
+`$CONDA_PREFIX/etc/conda/deactivate.d/reset-cuda.sh`
+
+```bash
 #!/bin/bash
-source ~/Projects/switch-cuda.sh default
+source ~/switch-cuda.sh default
 ```
 
-**Usage**
+Now:
 
-Now, whenever you activate `YOUR_ENV_NAME`:
-```
+```bash
 conda activate YOUR_ENV_NAME
 ```
-It will automatically switch to `12.1`.
 
-And when you deactivate:
-```
+switches to CUDA `12.1`, and:
+
+```bash
 conda deactivate
 ```
-It will reset back to the system default CUDA setup.
 
-
+restores system default CUDA.

--- a/switch-cuda.sh
+++ b/switch-cuda.sh
@@ -45,12 +45,52 @@ if [[ -z ${TARGET_VERSION} ]]; then
     done
     set +e
     return
+
+# if target is 'default' → clean CUDA environment variables
+elif [[ "${TARGET_VERSION}" == "default" ]]; then
+    # Remove CUDA entries from PATH
+    path_elements=(${PATH//:/ })
+    new_path=""
+    for p in "${path_elements[@]}"; do
+        if [[ ! ${p} =~ ^${INSTALL_FOLDER}/cuda ]]; then
+            if [[ -z "${new_path}" ]]; then
+                new_path="${p}"
+            else
+                new_path="${new_path}:${p}"
+            fi
+        fi
+    done
+    export PATH="${new_path}"
+
+    # Remove CUDA entries from LD_LIBRARY_PATH
+    ld_path_elements=(${LD_LIBRARY_PATH//:/ })
+    new_ld_path=""
+    for p in "${ld_path_elements[@]}"; do
+        if [[ ! ${p} =~ ^${INSTALL_FOLDER}/cuda ]]; then
+            if [[ -z "${new_ld_path}" ]]; then
+                new_ld_path="${p}"
+            else
+                new_ld_path="${new_ld_path}:${p}"
+            fi
+        fi
+    done
+    export LD_LIBRARY_PATH="${new_ld_path}"
+
+    # Unset CUDA-specific variables
+    unset CUDA_HOME
+    unset CUDA_ROOT
+
+    echo "CUDA environment has been reset to default."
+    set +e
+    return
+
 # otherwise, check whether there is an installation of the requested CUDA version
 elif [[ ! -d "${INSTALL_FOLDER}/cuda-${TARGET_VERSION}" ]]; then
     echo "No installation of CUDA ${TARGET_VERSION} has been found!"
     set +e
     return
 fi
+
 
 # the path of the installation to use
 cuda_path="${INSTALL_FOLDER}/cuda-${TARGET_VERSION}"


### PR DESCRIPTION
### Description

This PR enhances the `switch-cuda.sh` script by introducing a `default `option, which resets the CUDA-related environment variables and restores the system’s default CUDA setup (as determined by the `/usr/local/cuda` symbolic link).

### Changes
- Added support for source switch-cuda.sh default to:

    - Remove CUDA paths from PATH and LD_LIBRARY_PATH

    - Unset CUDA_HOME and CUDA_ROOT

- Updated README.md

 ### Example usage

```
$ source switch-cuda.sh default
CUDA environment has been reset to default.
```